### PR TITLE
Update for PureScript 0.9

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,18 +18,16 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-control": "^0.3.0",
-    "purescript-eff": "^0.1.0",
-    "purescript-functions": "^0.1.0",
-    "purescript-context": "^1.0.0"
+    "purescript-context": "^1.0.0",
+    "purescript-control": "^1.0.0",
+    "purescript-eff": "^1.0.0",
+    "purescript-functions": "^1.0.1",
+    "purescript-prelude": "^1.0.1"
   },
   "devDependencies": {
-    "purescript-aff": "^0.11.3",
-    "purescript-random": "^0.2.2",
-    "purescript-spec": "^0.7.1",
-    "purescript-spec-quickcheck": "^0.3.0"
-  },
-  "resolutions": {
-    "purescript-spec": "^0.7.1"
+    "purescript-aff": "^1.0.0",
+    "purescript-random": "^1.0.0",
+    "purescript-spec": "^0.8.0",
+    "purescript-spec-quickcheck": "^0.9.1"
   }
 }

--- a/src/Data/Foreign/OOFFI.purs
+++ b/src/Data/Foreign/OOFFI.purs
@@ -18,10 +18,10 @@ module Data.Foreign.OOFFI
 
 import Prelude
 
-import Control.Bind      ((<=<))
-import Control.Monad.Eff (Eff())
-import Data.Function     -- runFnX
-import Foreign.Context   (getContext)
+import Control.Bind            ((<=<))
+import Control.Monad.Eff       (Eff())
+import Data.Function.Uncurried (runFn0, runFn1, runFn2, runFn3, runFn4, runFn5)
+import Foreign.Context         (getContext)
 
 -- Helper Functions -----------------------------------------------------------
 
@@ -30,8 +30,10 @@ foreign import instantiateImpl :: forall c fn ret eff. c -> fn (Eff eff ret)
 foreign import mapEff          :: forall fn ret eff. fn ret -> fn (Eff eff ret)
 foreign import unsafeGetter    :: forall o a. String -> o -> a
 
-(..) :: forall a b c d. (c -> d) -> (a -> b -> c) -> a -> b -> d
-(..) f g a b = f (g a b)
+compose2 :: forall a b c d. (c -> d) -> (a -> b -> c) -> a -> b -> d
+compose2 f g a b = f (g a b)
+
+infixr 9 compose2 as ..
 
 -- Property Access ------------------------------------------------------------
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,18 +4,25 @@ import Prelude
 
 import Control.Apply              ((*>))
 import Control.Monad.Aff          (Aff()) -- MonadEff Aff
-import Control.Monad.Eff.Console  (CONSOLE(), log)
+import Control.Monad.Eff.Console  (CONSOLE())
 import Control.Monad.Eff          (Eff())
 import Control.Monad.Eff.Class    (liftEff)
 import Control.Monad.Eff.Random   (RANDOM(), random, randomBool)
 import Foreign.Context            (Context(), getContext)
+import Node.Process               (PROCESS())
 import Test.Spec                  (describe, it)
 import Test.Spec.Assertions       (shouldEqual)
 import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner           (Process(), run)
 import Test.Spec.QuickCheck       (quickCheck)
+import Test.Spec.Runner           (run)
 
-import Data.Foreign.OOFFI
+import Data.Foreign.OOFFI         ( method0, method0Eff, method1, method1Eff
+                                  , method2, method2Eff, method3, method3Eff
+                                  , method4, method4Eff, method5, method5Eff
+                                  , getter, modifier, setter
+                                  , instantiate0, instantiate1, instantiate2
+                                  , instantiate3, instantiate4, instantiate5
+                                  )
 
 foreign import data TestObj :: *
 foreign import data OOTEST :: !
@@ -23,12 +30,13 @@ foreign import data OOTEST :: !
 foreign import obj :: TestObj
 foreign import assignContext :: forall eff. Context -> Eff eff Unit
 
-type Effit ret = Eff (ooTest :: OOTEST, random :: RANDOM, console :: CONSOLE, process :: Process) ret
-type Affit ret = Aff (ooTest :: OOTEST, random :: RANDOM, console :: CONSOLE, process :: Process) ret
+type Effit ret = Eff (ooTest :: OOTEST, random :: RANDOM, console :: CONSOLE, process :: PROCESS) ret
+type Affit ret = Aff (ooTest :: OOTEST, random :: RANDOM, console :: CONSOLE, process :: PROCESS) ret
 
 lift' :: forall a. Effit a -> Affit a
 lift' = liftEff
 
+main :: Effit Unit
 main = (getContext >>= assignContext) *> run [consoleReporter] do
   describe "OOFFI" do
     describe "the method functions" do


### PR DESCRIPTION
This commit updates the dependencies in `bower.json`. It also fixes the changes since PureScript 0.7 and silences all warnings. Note that I had to give the `(..)` operator a name, so I chose `compose2`; hopefully that's acceptable. I gave it the same precedence as `<<<`.
